### PR TITLE
Prevent autocorrect and autocapitalization

### DIFF
--- a/src/main/java/com/fave100/client/pagefragments/login/LoginWidgetView.ui.xml
+++ b/src/main/java/com/fave100/client/pagefragments/login/LoginWidgetView.ui.xml
@@ -47,7 +47,7 @@
 			<g:HTMLPanel styleName="nativeLoginBox">
 				<div class="{style.field}">
 					<g:Label>Username</g:Label>
-					<g:TextBox ui:field="usernameInput" />
+					<my:FaveTextBox ui:field="usernameInput"/>
 				</div>
 				<div class="{style.field}">
 					<g:Label>Password</g:Label>

--- a/src/main/java/com/fave100/client/pagefragments/register/RegisterWidgetView.ui.xml
+++ b/src/main/java/com/fave100/client/pagefragments/register/RegisterWidgetView.ui.xml
@@ -59,12 +59,12 @@
 			<g:HTMLPanel styleName="{style.registerForm} {style.nativeRegisterForm}">	
 				<div class="{style.field}">				
 					<g:Label>Username</g:Label>					
-					<g:TextBox ui:field="usernameField"/>
+					<my:FaveTextBox ui:field="usernameField"/>
 					<span class="{style.statusMessage} error" ui:field="usernameStatusMessage"/>
 				</div>
 				<div class="{style.field}">
 					<g:Label>Email</g:Label>					
-					<g:TextBox ui:field="emailField"/>
+					<my:FaveTextBox ui:field="emailField"/>
 					<span class="{style.statusMessage} error" ui:field="emailStatusMessage"/>
 				</div>
 				<div class="{style.field}">

--- a/src/main/java/com/fave100/client/pages/lists/widgets/autocomplete/list/ListAutocompleteView.ui.xml
+++ b/src/main/java/com/fave100/client/pages/lists/widgets/autocomplete/list/ListAutocompleteView.ui.xml
@@ -1,5 +1,6 @@
 <ui:UiBinder xmlns:ui='urn:ui:com.google.gwt.uibinder'
-             xmlns:g='urn:import:com.google.gwt.user.client.ui'>
+             xmlns:g='urn:import:com.google.gwt.user.client.ui'
+             xmlns:w='urn:import:com.fave100.client.widgets'>
            
 	<ui:style src="../../../../../../client/resources/css/global.css" type="com.fave100.client.pages.lists.widgets.autocomplete.list.ListAutocompleteView.ListAutocompleteStyle">
     
@@ -28,7 +29,7 @@
     </ui:style>
     
     <g:HTMLPanel>
-    	<g:TextBox ui:field="searchBox" ui:styleName="{style.searchBox}"/>
+    	<w:FaveTextBox ui:field="searchBox" ui:styleName="{style.searchBox}"/>
     	<g:FlowPanel ui:field="resultsPanel" ui:styleName="{style.resultsPanel}"/>
     	<g:Label ui:field="noResultsMsg" ui:styleName="{style.noResultsMsg}">No results found</g:Label>
     </g:HTMLPanel>

--- a/src/main/java/com/fave100/client/pages/lists/widgets/autocomplete/song/SongAutocompleteView.ui.xml
+++ b/src/main/java/com/fave100/client/pages/lists/widgets/autocomplete/song/SongAutocompleteView.ui.xml
@@ -2,7 +2,8 @@
 
 <ui:UiBinder xmlns:ui='urn:ui:com.google.gwt.uibinder'
 	xmlns:g='urn:import:com.google.gwt.user.client.ui'
-	xmlns:w='urn:import:com.fave100.client.widgets.helpbubble'
+	xmlns:w='urn:import:com.fave100.client.widgets'
+	xmlns:wh='urn:import:com.fave100.client.widgets.helpbubble'
 	ui:generateFormat='com.google.gwt.i18n.rebind.format.PropertiesFormat'
 	ui:generateKeys='com.google.gwt.i18n.rebind.keygen.MD5KeyGenerator'
 	ui:generateLocales='default'>
@@ -132,7 +133,7 @@
 	
 	<g:HTMLPanel>
 		<div class="{style.searchArea}">
-			<g:TextBox ui:field="searchBox" ui:styleName="{style.searchBox}"/>
+			<w:FaveTextBox ui:field="searchBox" ui:styleName="{style.searchBox}"/>
 			<g:HTMLPanel ui:styleName="{style.searchBoxDetails}">				
 				<g:HTMLPanel ui:field="searchLoadingIndicator" ui:styleName="{style.searchLoadingIndicator}">
 					<g:Image resource="{img.searchLoadingIndicator}" />
@@ -143,7 +144,7 @@
 			<g:FocusPanel ui:field="backToTopButton" ui:styleName="{style.backToTopButton}">
 				<g:Image resource="{img.upArrow}" ></g:Image>
 			</g:FocusPanel>
-			<w:HelpBubble ui:field="helpBubble" ui:styleName="{style.helpBubble}"/>
+			<wh:HelpBubble ui:field="helpBubble" ui:styleName="{style.helpBubble}"/>
 		</div>		
 		<g:HTMLPanel ui:field="resultsArea" ui:styleName="{style.resultsArea} autocompleteResultsArea">
 			<g:FocusPanel ui:field="eventCatcher">

--- a/src/main/java/com/fave100/client/pages/passwordreset/PasswordResetView.ui.xml
+++ b/src/main/java/com/fave100/client/pages/passwordreset/PasswordResetView.ui.xml
@@ -2,6 +2,7 @@
 
 <ui:UiBinder xmlns:ui='urn:ui:com.google.gwt.uibinder'
 	xmlns:g='urn:import:com.google.gwt.user.client.ui'
+	xmlns:w='urn:import:com.fave100.client.widgets'
 	xmlns:pf='urn:import:com.fave100.client.pagefragments.footer'
 	ui:generateFormat='com.google.gwt.i18n.rebind.format.PropertiesFormat'
 	ui:generateKeys='com.google.gwt.i18n.rebind.keygen.MD5KeyGenerator'
@@ -44,9 +45,9 @@
 			<g:FormPanel ui:field="sendTokenForm" ui:styleName="{style.passwordResetForm}">
 				<g:VerticalPanel ui:styleName="{style.inputContainer}">
 					<g:Label>Username</g:Label>
-					<g:TextBox ui:field="usernameInput"/>
+					<w:FaveTextBox ui:field="usernameInput"/>
 					<g:Label>Email</g:Label>
-					<g:TextBox ui:field="emailInput"/>
+					<w:FaveTextBox ui:field="emailInput"/>					
 					<g:Label ui:field="tokenStatusMessage"/>
 					<g:SubmitButton ui:field="sendTokenButton">Send</g:SubmitButton>
 				</g:VerticalPanel>

--- a/src/main/java/com/fave100/client/pages/profile/ProfileView.ui.xml
+++ b/src/main/java/com/fave100/client/pages/profile/ProfileView.ui.xml
@@ -2,6 +2,7 @@
 
 <ui:UiBinder xmlns:ui='urn:ui:com.google.gwt.uibinder'
 	xmlns:g='urn:import:com.google.gwt.user.client.ui'
+	xmlns:w='urn:import:com.fave100.client.widgets'
 	xmlns:pf='urn:import:com.fave100.client.pagefragments.footer'
 	ui:generateFormat='com.google.gwt.i18n.rebind.format.PropertiesFormat'
 	ui:generateKeys='com.google.gwt.i18n.rebind.keygen.MD5KeyGenerator'
@@ -33,7 +34,7 @@
 				<h2 class="{style.pageTitle}">Profile</h2>
 				<g:HTMLPanel styleName="registerContainer profileForm">			
 					<g:Label>Email</g:Label>					
-					<g:TextBox  ui:field="emailInput"/>
+					<w:FaveTextBox  ui:field="emailInput"/>
 					<g:Label styleName="error inputStatusMessage" ui:field="emailStatusMessage"/>
 					<g:Hyperlink targetHistoryToken="{nameTokens.getPasswordreset}">Change your password</g:Hyperlink>
 					<h4>Privacy</h4>

--- a/src/main/java/com/fave100/client/pages/register/RegisterView.ui.xml
+++ b/src/main/java/com/fave100/client/pages/register/RegisterView.ui.xml
@@ -2,6 +2,7 @@
 
 <ui:UiBinder xmlns:ui='urn:ui:com.google.gwt.uibinder'
 	xmlns:g='urn:import:com.google.gwt.user.client.ui'
+	xmlns:w='urn:import:com.fave100.client.widgets'
 	xmlns:pf='urn:import:com.fave100.client.pagefragments.footer'
 	ui:generateFormat='com.google.gwt.i18n.rebind.format.PropertiesFormat'
 	ui:generateKeys='com.google.gwt.i18n.rebind.keygen.MD5KeyGenerator'
@@ -86,7 +87,7 @@
 						<g:FormPanel ui:field="thirdPartyRegisterForm">
 							<g:HTMLPanel ui:styleName="registerContainer {style.thirdPartyUsernamePrompt}">
 								<span>Please enter a username to complete the registration process</span>
-								<g:TextBox ui:field="thirdPartyUsernameField"/>
+								<w:FaveTextBox ui:field="thirdPartyUsernameField"/>
 								<span class="{style.statusMessage} error" ui:field="thirdPartyUsernameStatusMessage"/>					
 								<g:SubmitButton ui:field="thirdPartyUsernameSubmitButton">Submit</g:SubmitButton>
 							</g:HTMLPanel>

--- a/src/main/java/com/fave100/client/widgets/FaveTextBox.java
+++ b/src/main/java/com/fave100/client/widgets/FaveTextBox.java
@@ -1,0 +1,12 @@
+package com.fave100.client.widgets;
+
+import com.google.gwt.user.client.ui.TextBox;
+
+public class FaveTextBox extends TextBox {
+
+	public FaveTextBox() {
+		this.getElement().setAttribute("autocorrect", "off");
+		this.getElement().setAttribute("autocapitalize", "off");
+	}
+
+}


### PR DESCRIPTION
For example, when typing in username into login, iOS browser will autocapitalize and offer autocorrect suggestions. This is annoying (since it is very likely that the first letter is not capitalized and that the username is not a proper word) and will now be prevented.
