### PR TITLE
Switch search service URL to new server, update GWT to 2.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,15 +5,16 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.fave100</groupId>
 	<artifactId>fave100</artifactId>
-	<packaging>war</packaging>
+	<packaging>gwt-app</packaging>
 	<version>1.0.0-SNAPSHOT</version>
 	<name>gwt-maven-archetype-project</name>
 
+
 	<properties>
-		<gwt.version>2.6.1</gwt.version>
+		<gwt.version>2.7.0</gwt.version>
 		<appengine.version>1.9.59</appengine.version>
 		<gwt-maven-plugin.version>2.5.1</gwt-maven-plugin.version>
-		<gwtp.version>1.3.1</gwtp.version>
+		<gwtp.version>1.4</gwtp.version>
 		<jersey.version>1.18</jersey.version>
 		<powermock.version>1.5.4</powermock.version>
 		<war.path>src/main/webapp/</war.path>
@@ -24,15 +25,10 @@
 	</properties>
 
 	<repositories>
-		<!-- temporary repo for gss.gwt snapshot -->
 		<repository>
-	        <id>sonatype.snapshots</id>
-	        <name>Sonatype snapshot repository</name>
-	        <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
-	        <snapshots>
-	           <enabled>true</enabled>
-	        </snapshots>
-	    </repository>
+			<id>jitpack.io</id>
+			<url>https://jitpack.io</url>
+		</repository>
 	</repositories>
 
 	<pluginRepositories>
@@ -83,6 +79,12 @@
 			<groupId>com.sun.jersey</groupId>
 			<artifactId>jersey-server</artifactId>
 			<version>${jersey.version}</version>
+			<exclusions>
+				<exclusion>
+					<artifactId>asm</artifactId>
+					<groupId>asm</groupId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 
 		<dependency>
@@ -171,7 +173,14 @@
 			<version>2.1.2</version>
 			<scope>provided</scope>
 		</dependency>
-		
+
+		<dependency>
+			<groupId>com.gwtplatform.extensions</groupId>
+			<artifactId>ginuibinder</artifactId>
+			<version>2.8.0</version>
+		</dependency>
+
+
 		<dependency>
 			<groupId>com.google.gwt</groupId>
 			<artifactId>gwt-user</artifactId>
@@ -211,6 +220,13 @@
 
 		<dependency>
 			<groupId>com.gwtplatform</groupId>
+			<artifactId>gwtp-dispatch-rest-shared</artifactId>
+			<version>${gwtp.version}</version>
+			<scope>compile</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>com.gwtplatform</groupId>
 			<artifactId>gwtp-processors</artifactId>
 			<version>${gwtp.version}</version>
 			<scope>provided</scope>
@@ -226,12 +242,21 @@
 		</dependency>
 
 		<!-- GSS Resource -->
-		<dependency>
-	        <groupId>com.github.jdramaix</groupId>
-	        <artifactId>gssresource</artifactId>
-	        <version>1.0-20140825.095751-42</version>
-	        <scope>provided</scope>
-	    </dependency>
+<!--		<dependency>-->
+<!--	        <groupId>com.github.jdramaix</groupId>-->
+<!--	        <artifactId>gssresource</artifactId>-->
+<!--	        <version>1.0-20140825.095751-42</version>-->
+<!--	        <scope>provided</scope>-->
+<!--	    </dependency>-->
+
+
+<!--		<dependency>-->
+<!--			<groupId>com.github.jDramaix</groupId>-->
+<!--			<artifactId>gss.gwt</artifactId>-->
+<!--			<version>58c1a888</version>-->
+<!--		</dependency>-->
+
+
 
 		<!-- End Client -->
 		<!-- Begin Test -->
@@ -337,6 +362,17 @@
 					<version>${appengine-app-version}</version>
 					<noCookies>true</noCookies>
 					<passin>true</passin>
+				</configuration>
+			</plugin>
+
+			<plugin>
+				<groupId>net.ltgt.gwt.maven</groupId>
+				<artifactId>gwt-maven-plugin</artifactId>
+				<version>1.0.0</version>
+				<extensions>true</extensions>
+
+				<configuration>
+					<moduleName>com.fave100.Fave100</moduleName>
 				</configuration>
 			</plugin>
 

--- a/src/main/java/com/fave100/Fave100.gwt.xml
+++ b/src/main/java/com/fave100/Fave100.gwt.xml
@@ -10,7 +10,7 @@
 	<inherits name='com.gwtplatform.mvp.MvpWithEntryPoint' />
 	<inherits name='com.google.gwt.logging.LoggingDisabled' />
 	<inherits name='com.google.gwt.query.Query' />
-	<inherits name="com.google.gwt.resources.GssResource" />
+<!--	<inherits name="com.google.gwt.resources.CssResource" />-->
 
 	<!-- Specify the paths for translatable code -->
 	<source path='client' />
@@ -19,5 +19,7 @@
 	<!-- GWTP Bootstrap and Inject -->
 	<extend-configuration-property name='gin.ginjector.modules' value='com.fave100.client.gin.ClientModule' />
 	<set-configuration-property name="gwtp.bootstrapper" value="com.fave100.client.Fave100Bootstrapper" />
+
+	<set-configuration-property name="CssResource.enableGss" value="true"/>
 
 </module>

--- a/src/main/java/com/fave100/client/CurrentUser.java
+++ b/src/main/java/com/fave100/client/CurrentUser.java
@@ -1,10 +1,5 @@
 package com.fave100.client;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
 import com.fave100.client.RequestCache.RequestType;
 import com.fave100.client.events.LoginDialogRequestedEvent;
 import com.fave100.client.events.favelist.AddSongListsSelectedEvent;
@@ -22,9 +17,14 @@ import com.google.gwt.http.client.Response;
 import com.google.gwt.user.client.rpc.AsyncCallback;
 import com.google.inject.Inject;
 import com.google.web.bindery.event.shared.EventBus;
-import com.gwtplatform.dispatch.rest.shared.RestCallback;
+import com.gwtplatform.dispatch.rest.client.RestCallback;
 import com.gwtplatform.mvp.client.proxy.PlaceManager;
 import com.gwtplatform.mvp.shared.proxy.PlaceRequest;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 public class CurrentUser extends AppUser {
 
@@ -101,11 +101,11 @@ public class CurrentUser extends AppUser {
 	private void resetState() {
 		appUser = null;
 		avatar = "";
-		faveLists = new HashMap<String, List<FaveItem>>();
+		faveLists = new HashMap<>();
 		followingResult = null;
 		fullListRetrieved = false;
 		_currentHashtag = Constants.DEFAULT_HASHTAG;
-		_hashtags = new ArrayList<String>();
+		_hashtags = new ArrayList<>();
 		setAfterLoginAction(null);
 	}
 

--- a/src/main/java/com/fave100/client/generated/services/AuthService.java
+++ b/src/main/java/com/fave100/client/generated/services/AuthService.java
@@ -9,22 +9,16 @@
 
 package com.fave100.client.generated.services;
 
-import com.fave100.client.generated.entities.FacebookRegistration;
-import com.fave100.client.generated.entities.UserRegistration;
-import com.fave100.client.generated.entities.LoginCredentials;
-import javax.ws.rs.Path;
+import com.fave100.client.generated.entities.*;
 import com.gwtplatform.dispatch.rest.shared.RestAction;
+
 import javax.ws.rs.GET;
-import com.fave100.client.generated.entities.AppUser;
-import com.gwtplatform.dispatch.rest.shared.RestService;
-import com.fave100.client.generated.entities.StringResult;
 import javax.ws.rs.POST;
-import com.fave100.client.generated.entities.TwitterRegistration;
-import javax.ws.rs.PathParam;
+import javax.ws.rs.Path;
 import javax.ws.rs.QueryParam;
 
 @Path("/")
-public interface AuthService extends RestService {
+public interface AuthService {
 
     @POST
     @Path("/auth/logout")

--- a/src/main/java/com/fave100/client/generated/services/FavelistsService.java
+++ b/src/main/java/com/fave100/client/generated/services/FavelistsService.java
@@ -9,22 +9,16 @@
 
 package com.fave100.client.generated.services;
 
-import com.fave100.client.generated.entities.FeaturedLists;
-import com.fave100.client.generated.entities.FaveItemCollection;
-import com.gwtplatform.dispatch.rest.shared.RestService;
-import javax.ws.rs.POST;
-import javax.ws.rs.PathParam;
-import com.fave100.client.generated.entities.StringResultCollection;
 import com.fave100.client.generated.entities.BooleanResult;
+import com.fave100.client.generated.entities.FaveItemCollection;
+import com.fave100.client.generated.entities.FeaturedLists;
+import com.fave100.client.generated.entities.StringResultCollection;
 import com.gwtplatform.dispatch.rest.shared.RestAction;
-import javax.ws.rs.Path;
-import javax.ws.rs.GET;
-import com.fave100.client.generated.entities.AppUser;
-import javax.ws.rs.QueryParam;
-import javax.ws.rs.DELETE;
+
+import javax.ws.rs.*;
 
 @Path("/")
-public interface FavelistsService extends RestService {
+public interface FavelistsService {
 
     @GET
     @Path("/favelists/names")

--- a/src/main/java/com/fave100/client/generated/services/SearchService.java
+++ b/src/main/java/com/fave100/client/generated/services/SearchService.java
@@ -9,17 +9,16 @@
 
 package com.fave100.client.generated.services;
 
-import com.gwtplatform.dispatch.rest.shared.RestService;
-import javax.ws.rs.PathParam;
-import com.fave100.client.generated.entities.YouTubeSearchResultCollection;
 import com.fave100.client.generated.entities.CursoredSearchResult;
+import com.fave100.client.generated.entities.YouTubeSearchResultCollection;
 import com.gwtplatform.dispatch.rest.shared.RestAction;
-import javax.ws.rs.Path;
+
 import javax.ws.rs.GET;
+import javax.ws.rs.Path;
 import javax.ws.rs.QueryParam;
 
 @Path("/")
-public interface SearchService extends RestService {
+public interface SearchService {
 
     @GET
     @Path("/search/users")

--- a/src/main/java/com/fave100/client/generated/services/SongsService.java
+++ b/src/main/java/com/fave100/client/generated/services/SongsService.java
@@ -9,18 +9,17 @@
 
 package com.fave100.client.generated.services;
 
-import com.fave100.client.generated.entities.WhylineCollection;
-import com.gwtplatform.dispatch.rest.shared.RestService;
 import com.fave100.client.generated.entities.FaveItem;
-import javax.ws.rs.PathParam;
-import com.gwtplatform.dispatch.rest.shared.RestAction;
-import javax.ws.rs.Path;
-import javax.ws.rs.GET;
-import javax.ws.rs.QueryParam;
 import com.fave100.client.generated.entities.UserListResultCollection;
+import com.fave100.client.generated.entities.WhylineCollection;
+import com.gwtplatform.dispatch.rest.shared.RestAction;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
 
 @Path("/")
-public interface SongsService extends RestService {
+public interface SongsService {
 
     @GET
     @Path("/songs/{id}")

--- a/src/main/java/com/fave100/client/generated/services/TrendingService.java
+++ b/src/main/java/com/fave100/client/generated/services/TrendingService.java
@@ -9,16 +9,14 @@
 
 package com.fave100.client.generated.services;
 
-import com.gwtplatform.dispatch.rest.shared.RestService;
-import javax.ws.rs.PathParam;
 import com.fave100.client.generated.entities.StringResultCollection;
 import com.gwtplatform.dispatch.rest.shared.RestAction;
-import javax.ws.rs.Path;
+
 import javax.ws.rs.GET;
-import javax.ws.rs.QueryParam;
+import javax.ws.rs.Path;
 
 @Path("/")
-public interface TrendingService extends RestService {
+public interface TrendingService {
 
     @GET
     @Path("/trending/favelists")

--- a/src/main/java/com/fave100/client/generated/services/UserService.java
+++ b/src/main/java/com/fave100/client/generated/services/UserService.java
@@ -9,26 +9,13 @@
 
 package com.fave100.client.generated.services;
 
-import com.fave100.client.generated.entities.AppUserCollection;
-import com.fave100.client.generated.entities.PasswordChangeDetails;
-import com.fave100.client.generated.entities.BooleanResult;
-import javax.ws.rs.Path;
-import javax.ws.rs.PUT;
+import com.fave100.client.generated.entities.*;
 import com.gwtplatform.dispatch.rest.shared.RestAction;
-import javax.ws.rs.GET;
-import com.fave100.client.generated.entities.AppUser;
-import com.fave100.client.generated.entities.EmailPasswordResetDetails;
-import com.gwtplatform.dispatch.rest.shared.RestService;
-import com.fave100.client.generated.entities.StringResult;
-import javax.ws.rs.POST;
-import com.fave100.client.generated.entities.UserInfo;
-import javax.ws.rs.PathParam;
-import com.fave100.client.generated.entities.WhylineEdit;
-import javax.ws.rs.QueryParam;
-import javax.ws.rs.DELETE;
+
+import javax.ws.rs.*;
 
 @Path("/")
-public interface UserService extends RestService {
+public interface UserService {
 
     @PUT
     @Path("/user/following/{user}")

--- a/src/main/java/com/fave100/client/generated/services/UsersService.java
+++ b/src/main/java/com/fave100/client/generated/services/UsersService.java
@@ -9,20 +9,16 @@
 
 package com.fave100.client.generated.services;
 
-import com.fave100.client.generated.entities.FaveItemCollection;
-import com.gwtplatform.dispatch.rest.shared.RestService;
-import com.fave100.client.generated.entities.StringResult;
-import javax.ws.rs.POST;
-import javax.ws.rs.PathParam;
-import com.fave100.client.generated.entities.FollowingResult;
-import com.gwtplatform.dispatch.rest.shared.RestAction;
-import javax.ws.rs.Path;
-import javax.ws.rs.GET;
 import com.fave100.client.generated.entities.AppUser;
-import javax.ws.rs.QueryParam;
+import com.fave100.client.generated.entities.FaveItemCollection;
+import com.fave100.client.generated.entities.FollowingResult;
+import com.fave100.client.generated.entities.StringResult;
+import com.gwtplatform.dispatch.rest.shared.RestAction;
+
+import javax.ws.rs.*;
 
 @Path("/")
-public interface UsersService extends RestService {
+public interface UsersService {
 
     @GET
     @Path("/users/{user}/favelists/{list}")

--- a/src/main/java/com/fave100/client/pagefragments/login/LoginWidgetPresenter.java
+++ b/src/main/java/com/fave100/client/pagefragments/login/LoginWidgetPresenter.java
@@ -14,7 +14,7 @@ import com.google.gwt.user.client.Window;
 import com.google.gwt.user.client.rpc.AsyncCallback;
 import com.google.inject.Inject;
 import com.google.web.bindery.event.shared.EventBus;
-import com.gwtplatform.dispatch.rest.shared.RestCallback;
+import com.gwtplatform.dispatch.rest.client.RestCallback;
 import com.gwtplatform.mvp.client.HasUiHandlers;
 import com.gwtplatform.mvp.client.PresenterWidget;
 import com.gwtplatform.mvp.client.UiHandlers;

--- a/src/main/java/com/fave100/client/pagefragments/register/RegisterWidgetPresenter.java
+++ b/src/main/java/com/fave100/client/pagefragments/register/RegisterWidgetPresenter.java
@@ -11,7 +11,7 @@ import com.fave100.shared.place.PlaceParams;
 import com.google.gwt.http.client.Response;
 import com.google.inject.Inject;
 import com.google.web.bindery.event.shared.EventBus;
-import com.gwtplatform.dispatch.rest.shared.RestCallback;
+import com.gwtplatform.dispatch.rest.client.RestCallback;
 import com.gwtplatform.mvp.client.HasUiHandlers;
 import com.gwtplatform.mvp.client.PresenterWidget;
 import com.gwtplatform.mvp.client.UiHandlers;

--- a/src/main/java/com/fave100/client/pages/admin/AdminPresenter.java
+++ b/src/main/java/com/fave100/client/pages/admin/AdminPresenter.java
@@ -1,8 +1,5 @@
 package com.fave100.client.pages.admin;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import com.fave100.client.FaveApi;
 import com.fave100.client.Notification;
 import com.fave100.client.gatekeepers.AdminGatekeeper;
@@ -20,7 +17,7 @@ import com.google.gwt.http.client.Response;
 import com.google.gwt.user.client.rpc.AsyncCallback;
 import com.google.inject.Inject;
 import com.google.web.bindery.event.shared.EventBus;
-import com.gwtplatform.dispatch.rest.shared.RestCallback;
+import com.gwtplatform.dispatch.rest.client.RestCallback;
 import com.gwtplatform.mvp.client.HasUiHandlers;
 import com.gwtplatform.mvp.client.View;
 import com.gwtplatform.mvp.client.annotations.ContentSlot;
@@ -29,6 +26,9 @@ import com.gwtplatform.mvp.client.annotations.ProxyCodeSplit;
 import com.gwtplatform.mvp.client.annotations.UseGatekeeper;
 import com.gwtplatform.mvp.client.proxy.ProxyPlace;
 import com.gwtplatform.mvp.client.proxy.RevealContentHandler;
+
+import java.util.ArrayList;
+import java.util.List;
 
 public class AdminPresenter extends PagePresenter<AdminPresenter.MyView, AdminPresenter.MyProxy> implements AdminUiHandlers {
 

--- a/src/main/java/com/fave100/client/pages/lists/ListPresenter.java
+++ b/src/main/java/com/fave100/client/pages/lists/ListPresenter.java
@@ -32,7 +32,7 @@ import com.google.gwt.user.client.Window;
 import com.google.gwt.user.client.rpc.AsyncCallback;
 import com.google.inject.Inject;
 import com.google.web.bindery.event.shared.EventBus;
-import com.gwtplatform.dispatch.rest.shared.RestCallback;
+import com.gwtplatform.dispatch.rest.client.RestCallback;
 import com.gwtplatform.mvp.client.HasUiHandlers;
 import com.gwtplatform.mvp.client.UiHandlers;
 import com.gwtplatform.mvp.client.View;

--- a/src/main/java/com/fave100/client/pages/lists/widgets/favelist/FavelistPresenter.java
+++ b/src/main/java/com/fave100/client/pages/lists/widgets/favelist/FavelistPresenter.java
@@ -1,10 +1,5 @@
 package com.fave100.client.pages.lists.widgets.favelist;
 
-import static com.google.gwt.query.client.GQuery.$;
-
-import java.util.ArrayList;
-import java.util.List;
-
 import com.fave100.client.CurrentUser;
 import com.fave100.client.FaveApi;
 import com.fave100.client.Notification;
@@ -25,11 +20,16 @@ import com.google.gwt.user.client.Window;
 import com.google.gwt.user.client.rpc.AsyncCallback;
 import com.google.inject.Inject;
 import com.google.web.bindery.event.shared.EventBus;
-import com.gwtplatform.dispatch.rest.shared.RestCallback;
+import com.gwtplatform.dispatch.rest.client.RestCallback;
 import com.gwtplatform.mvp.client.HasUiHandlers;
 import com.gwtplatform.mvp.client.PresenterWidget;
 import com.gwtplatform.mvp.client.View;
 import com.gwtplatform.mvp.client.proxy.PlaceManager;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.google.gwt.query.client.GQuery.$;
 
 public class FavelistPresenter extends
 		PresenterWidget<FavelistPresenter.MyView>

--- a/src/main/java/com/fave100/client/pages/lists/widgets/listmanager/ListManagerPresenter.java
+++ b/src/main/java/com/fave100/client/pages/lists/widgets/listmanager/ListManagerPresenter.java
@@ -1,8 +1,5 @@
 package com.fave100.client.pages.lists.widgets.listmanager;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import com.fave100.client.CurrentUser;
 import com.fave100.client.FaveApi;
 import com.fave100.client.Notification;
@@ -21,7 +18,7 @@ import com.google.gwt.http.client.Response;
 import com.google.gwt.user.client.rpc.AsyncCallback;
 import com.google.inject.Inject;
 import com.google.web.bindery.event.shared.EventBus;
-import com.gwtplatform.dispatch.rest.shared.RestCallback;
+import com.gwtplatform.dispatch.rest.client.RestCallback;
 import com.gwtplatform.mvp.client.HasUiHandlers;
 import com.gwtplatform.mvp.client.PresenterWidget;
 import com.gwtplatform.mvp.client.UiHandlers;
@@ -30,6 +27,9 @@ import com.gwtplatform.mvp.client.annotations.ContentSlot;
 import com.gwtplatform.mvp.client.proxy.PlaceManager;
 import com.gwtplatform.mvp.client.proxy.RevealContentHandler;
 import com.gwtplatform.mvp.shared.proxy.PlaceRequest;
+
+import java.util.ArrayList;
+import java.util.List;
 
 public class ListManagerPresenter extends
 		PresenterWidget<ListManagerPresenter.MyView>

--- a/src/main/java/com/fave100/client/pages/lists/widgets/usersfollowing/UsersFollowingPresenter.java
+++ b/src/main/java/com/fave100/client/pages/lists/widgets/usersfollowing/UsersFollowingPresenter.java
@@ -1,8 +1,5 @@
 package com.fave100.client.pages.lists.widgets.usersfollowing;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import com.fave100.client.CurrentUser;
 import com.fave100.client.FaveApi;
 import com.fave100.client.RequestCache;
@@ -32,6 +29,9 @@ import com.gwtplatform.mvp.client.proxy.RevealContentHandler;
 import com.gwtplatform.mvp.shared.proxy.ParameterTokenFormatter;
 import com.gwtplatform.mvp.shared.proxy.PlaceRequest;
 
+import java.util.ArrayList;
+import java.util.List;
+
 public class UsersFollowingPresenter extends PresenterWidget<UsersFollowingPresenter.MyView>
 		implements UsersFollowingUiHandlers {
 
@@ -49,7 +49,7 @@ public class UsersFollowingPresenter extends PresenterWidget<UsersFollowingPrese
 		void hide();
 	}
 
-	@ContentSlot public static final Type<RevealContentHandler<?>> USER_AUTOCOMPLETE_SLOT = new Type<RevealContentHandler<?>>();
+	@ContentSlot public static final Type<RevealContentHandler<?>> USER_AUTOCOMPLETE_SLOT = new Type<>();
 
 	EventBus _eventBus;
 	CurrentUser _currentUser;

--- a/src/main/java/com/fave100/client/pages/passwordreset/PasswordResetPresenter.java
+++ b/src/main/java/com/fave100/client/pages/passwordreset/PasswordResetPresenter.java
@@ -12,7 +12,7 @@ import com.google.gwt.http.client.Response;
 import com.google.gwt.user.client.rpc.AsyncCallback;
 import com.google.inject.Inject;
 import com.google.web.bindery.event.shared.EventBus;
-import com.gwtplatform.dispatch.rest.shared.RestCallback;
+import com.gwtplatform.dispatch.rest.client.RestCallback;
 import com.gwtplatform.mvp.client.HasUiHandlers;
 import com.gwtplatform.mvp.client.UiHandlers;
 import com.gwtplatform.mvp.client.View;

--- a/src/main/java/com/fave100/client/pages/profile/ProfilePresenter.java
+++ b/src/main/java/com/fave100/client/pages/profile/ProfilePresenter.java
@@ -13,7 +13,7 @@ import com.google.gwt.http.client.Response;
 import com.google.gwt.user.client.rpc.AsyncCallback;
 import com.google.inject.Inject;
 import com.google.web.bindery.event.shared.EventBus;
-import com.gwtplatform.dispatch.rest.shared.RestCallback;
+import com.gwtplatform.dispatch.rest.client.RestCallback;
 import com.gwtplatform.mvp.client.HasUiHandlers;
 import com.gwtplatform.mvp.client.UiHandlers;
 import com.gwtplatform.mvp.client.View;

--- a/src/main/java/com/fave100/client/pages/register/RegisterPresenter.java
+++ b/src/main/java/com/fave100/client/pages/register/RegisterPresenter.java
@@ -17,7 +17,7 @@ import com.google.gwt.http.client.Response;
 import com.google.gwt.user.client.rpc.AsyncCallback;
 import com.google.inject.Inject;
 import com.google.web.bindery.event.shared.EventBus;
-import com.gwtplatform.dispatch.rest.shared.RestCallback;
+import com.gwtplatform.dispatch.rest.client.RestCallback;
 import com.gwtplatform.mvp.client.HasUiHandlers;
 import com.gwtplatform.mvp.client.UiHandlers;
 import com.gwtplatform.mvp.client.View;
@@ -52,7 +52,7 @@ public class RegisterPresenter extends
 		void clearThirdPartyErrors();
 	}
 
-	@ContentSlot public static final Type<RevealContentHandler<?>> REGISTER_SLOT = new Type<RevealContentHandler<?>>();
+	@ContentSlot public static final Type<RevealContentHandler<?>> REGISTER_SLOT = new Type<>();
 
 	@Inject private RegisterWidgetPresenter registerContainer;
 

--- a/src/main/java/com/fave100/client/resources/css/GlobalStyle.java
+++ b/src/main/java/com/fave100/client/resources/css/GlobalStyle.java
@@ -1,8 +1,8 @@
 package com.fave100.client.resources.css;
 
-import com.google.gwt.resources.client.GssResource;
+import com.google.gwt.resources.client.CssResource;
 
-public interface GlobalStyle extends GssResource {
+public interface GlobalStyle extends CssResource {
 
 	int SIDE_BAR_WIDTH();
 

--- a/src/main/java/com/fave100/shared/Constants.java
+++ b/src/main/java/com/fave100/shared/Constants.java
@@ -3,7 +3,7 @@ package com.fave100.shared;
 public class Constants {
 
 	public static final String DEFAULT_HASHTAG = "alltime";
-	public static final String SEARCH_SERVICE_URL = "http://default-environment-9n6mmewqkp.elasticbeanstalk.com";
+	public static final String SEARCH_SERVICE_URL = "http://fave100search-env.eba-2npcyhjc.us-east-2.elasticbeanstalk.com";
 	public static final String SEARCH_URL = SEARCH_SERVICE_URL + "/search?";
 	public static final String LOOKUP_URL = SEARCH_SERVICE_URL + "/lookup?";
 	public static final long MAX_AVATAR_SIZE = 1024 * 300; //300kb


### PR DESCRIPTION
Updates GWT to 2.7, and attempts to make necessary fixes to get that to work. Add GWT Maven plugin - I think previously we were relying on IDE build?

Changes the URL we point to for the search service - possibly we can avoid all this pain and figure out a simpler way to replace the URL in the existing bundle if we don't plan on making further changes.